### PR TITLE
Fixes error converting 400 HTTP response to JSON.

### DIFF
--- a/IBMQuantumExperience/IBMQuantumExperience.py
+++ b/IBMQuantumExperience/IBMQuantumExperience.py
@@ -151,7 +151,7 @@ class _Request(object):
         """
         if respond.status_code == 400:
             self.log.warning("Got a 400 code response to %s: %s", respond.url,
-                             respond.json())
+                             respond.text)
             return False
         try:
             self.result = respond.json()


### PR DESCRIPTION
When the respond status_code is 400 an attempt is made to log the
response by called json() method which has been reported to raise an exception. This fix logs the raw ascii text instead.