### PR TITLE
Adding backend's name to backend_status output

### DIFF
--- a/IBMQuantumExperience/IBMQuantumExperience.py
+++ b/IBMQuantumExperience/IBMQuantumExperience.py
@@ -623,6 +623,8 @@ class IBMQuantumExperience(object):
             ret['busy'] = bool(status['busy'])
         if 'lengthQueue' in status:
             ret['pending_jobs'] = status['lengthQueue']
+        
+        ret['backend'] = backend_type
 
         return ret
 


### PR DESCRIPTION
This should solve the following issue
https://github.com/QISKit/qiskit-api-py/issues/40