### PR TITLE
Make max_credits optional for run_job

### DIFF
--- a/IBMQuantumExperience/IBMQuantumExperience.py
+++ b/IBMQuantumExperience/IBMQuantumExperience.py
@@ -590,7 +590,7 @@ class IBMQuantumExperience(object):
             return respond
 
     def run_job(self, qasms, backend='simulator', shots=1,
-                max_credits=3, seed=None, hub=None, group=None,
+                max_credits=None, seed=None, hub=None, group=None,
                 project=None, access_token=None, user_id=None):
         """
         Execute a job
@@ -606,8 +606,9 @@ class IBMQuantumExperience(object):
             qasm['qasm'] = qasm['qasm'].replace('OPENQASM 2.0;', '')
         data = {'qasms': qasms,
                 'shots': shots,
-                'maxCredits': max_credits,
                 'backend': {}}
+        if max_credits:
+            data['maxCredits'] = max_credits
 
         backend_type = self._check_backend(backend, 'job')
 


### PR DESCRIPTION
Allow calling `run_job` with no `max_credit` parameter.